### PR TITLE
Correção Issue #40 Troco.java

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -69,7 +69,7 @@ class Troco {
         @Override
         public PapelMoeda next() {
             PapelMoeda ret = null;
-            for (int i = 6; i >= 0 && ret != null; i++) {
+            for (int i = 6; i >= 0 && ret == null; i++) {
                 if (troco.papeisMoeda[i] != null) {
                     ret = troco.papeisMoeda[i];
                     troco.papeisMoeda[i] = null;


### PR DESCRIPTION
Para corrigir a inicialização do loop, foi ajustado o para ret == null, garantindo que o loop seja interrompido assim que um elemento não nulo for encontrado. Isso permitirá uma iteração correta e eficiente sobre os elementos do iterator. #40