### PR TITLE
Correção Issue #38 Troco.java

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -58,7 +58,7 @@ class Troco {
 
         @Override
         public boolean hasNext() {
-            for (int i = 6; i >= 0; i++) {
+            for (int i = 5; i >= 0; i++) {
                 if (troco.papeisMoeda[i] != null) {
                     return true;
                 }


### PR DESCRIPTION
Alteração de inicialização da variável "i" na linha 61 para não exceder o limite do array, conforme descrito na Issue #38