### PR TITLE
Correção Issue #46 Troco.java

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -12,12 +12,10 @@ class Troco {
 
     public Troco(int valor) {
         papeisMoeda = new PapelMoeda[6];
-        int count = 0;
-        while (valor % 100 != 0) {
-            count++;
-        }
+        int count = valor / 100;
         papeisMoeda[5] = new PapelMoeda(100, count);
-        count = 0;
+        valor %= 100; 
+        
         while (valor % 50 != 0) {
             count++;
         }


### PR DESCRIPTION
Condição de contagem de notas 100 alterada para evitar o loop infinito na linha 16 mencionado na Issue #46 e contar corretamente a quantidade recebida.