### PR TITLE
Correção Issue #47 Troco.java

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -18,11 +18,11 @@ class Troco {
         }
         papeisMoeda[5] = new PapelMoeda(100, count);
         count = 0;
-        while (valor % 50 != 0) {
-            count++;
-        }
+
+        count = valor / 50; 
         papeisMoeda[4] = new PapelMoeda(50, count);
-        count = 0;
+        valor %= 50;
+
         while (valor % 20 != 0) {
             count++;
         }


### PR DESCRIPTION
Condição de contagem de notas 50 alterada para evitar o loop infinito na linha 21 mencionado na Issue #47  e contar corretamente a quantidade recebida.