### PR TITLE
Correção Issue #48 Troco.java

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -23,10 +23,11 @@ class Troco {
         }
         papeisMoeda[4] = new PapelMoeda(50, count);
         count = 0;
-        while (valor % 20 != 0) {
-            count++;
-        }
+
+        count = valor / 20; 
         papeisMoeda[3] = new PapelMoeda(20, count);
+        valor %= 20; 
+
         count = 0;
         while (valor % 10 != 0) {
             count++;


### PR DESCRIPTION
Condição de contagem de notas 20 alterada para evitar o loop infinito na linha 26 mencionado na Issue #48 e contar corretamente a quantidade recebida.