### PR TITLE
Correção Issue #49 Troco.java

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -28,11 +28,10 @@ class Troco {
         }
         papeisMoeda[3] = new PapelMoeda(20, count);
         count = 0;
-        while (valor % 10 != 0) {
-            count++;
-        }
+        
+        count = valor / 10; 
         papeisMoeda[2] = new PapelMoeda(10, count);
-        count = 0;
+        valor %= 10;
         while (valor % 5 != 0) {
             count++;
         }


### PR DESCRIPTION
Condição de contagem de notas 10 alterada para evitar o loop infinito na linha 31 mencionado na Issue #49  e contar corretamente a quantidade recebida.