### PR TITLE
Correção Issue 50 Troco.java

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -33,11 +33,10 @@ class Troco {
         }
         papeisMoeda[2] = new PapelMoeda(10, count);
         count = 0;
-        while (valor % 5 != 0) {
-            count++;
-        }
+       
+        count = valor / 5;
         papeisMoeda[1] = new PapelMoeda(5, count);
-        count = 0;
+        valor %= 5;
         while (valor % 2 != 0) {
             count++;
         }


### PR DESCRIPTION
Condição de contagem de notas 5 alterada para evitar o loop infinito na linha 36 mencionado na Issue #50  e contar corretamente a quantidade recebida.